### PR TITLE
Add `/feedback`

### DIFF
--- a/app.py
+++ b/app.py
@@ -138,13 +138,13 @@ def history():
 
 @app.route('/feedback', methods=['POST'])
 def feedback():
-    data = requrest.get_json()
-    feedback_content = data['content']
+    data = request.get_json()
+    feedback_content = data.get('content')
     if len(feedback_content) > 1000:
         raise InvalidUsage('feedback content is too long')
     today = datetime.today()
-    with open(cfg['feedback']['feedback_log_file'], mode='a'):
-        w.write(f'{today}\t{feedback_content}\n')
+    with open(cfg['feedback']['feedback_log_file'], mode='a') as f:
+        f.write(f'{today}\t{feedback_content}\n')
     # successfull response is empty
     return jsonify({})
 

--- a/app.py
+++ b/app.py
@@ -144,7 +144,7 @@ def feedback():
         raise InvalidUsage('feedback content is too long')
     today = datetime.today()
     with open(cfg['feedback']['feedback_log_file'], mode='a'):
-        w.write(f'{today} {feedback_content}')
+        w.write(f'{today}\t{feedback_content}\n')
     # successfull response is empty
     return jsonify({})
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 """An API server for covid-19-ui."""
 import json
 import os
+from datetime import datetime
 
 from mojimoji import han_to_zen
 from flask import Flask, request, jsonify
@@ -133,6 +134,19 @@ def history():
                     edited_info['is_checked'] = 1
                     return jsonify(edited_info)
     return jsonify({'url': url, 'is_checked': 0})
+
+
+@app.route('/feedback', methods=['POST'])
+def feedback():
+    data = requrest.get_json()
+    feedback_content = data['content']
+    if len(feedback_content) > 1000:
+        raise InvalidUsage('feedback content is too long')
+    today = datetime.today()
+    with open(cfg['feedback']['feedback_log_file'], mode='a'):
+        w.write(f'{today} {feedback_content}')
+    # successfull response is empty
+    return jsonify({})
 
 
 @app.route('/meta')

--- a/config.example.json
+++ b/config.example.json
@@ -18,6 +18,9 @@
     "result_dir": "<path-to-result-dir>",
     "useful_white_list": "<path-to-white-list-of-useful-pages>"
   },
+  "feedback": {
+    "feedback_log_file": "<path-to-feedback-log-file>"
+  },
   "source": "<path-to-information-source-list>",
   "password": "<password>"
 }


### PR DESCRIPTION
## What

Add feedback post request handler. Related to this:  [Add feedback UI by honai · Pull Request #71 · NLPforCOVID-19/covid-19-ui](https://github.com/NLPforCOVID-19/covid-19-ui/pull/71)

### Example Request
Path: `/feedback`
Method: POST
Data:
```
{ "content": "feedback input content" }
```
The maximum `content` length should be 1,000.

### Handle

Simply write to log file (TSV)
```
2020-11-11 11:11:11.23456    feedback input content
```

### Example Response
Status: 200, empty
```
{}
```

If the `content` length is greater than 1000, returns `400 Bad Request` .