### PR TITLE
Add an API to return Twitter data

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 }
 ```
 
-### [GET] /classes
+### [GET] /articles
 
 - Parameters
     - lang: string ('ja' or 'en')
@@ -125,7 +125,7 @@ One `<article-information>` is like:
 }
 ```
 
-### [GET] /classes/\<class_\>
+### [GET] /articles/\<class_\>
 
 `<class_>` must be an item in the topics in the meta-data.
 
@@ -150,7 +150,7 @@ One `<article-information>` is like:
 }
 ```
 
-### [GET] /classes/\<class_\>/\<country\>
+### [GET] /articles/\<class_\>/\<country\>
 
 `<country>` must be an item in the countries in the meta-data.
 
@@ -168,10 +168,6 @@ One `<article-information>` is like:
   "<article-information>"
 ]
 ```
-
-### [GET] /countries
-### [GET] /countries/\<country\>
-### [GET] /countries/\<country\>\<class_\>
 
 ## Developer Guides
 

--- a/app.py
+++ b/app.py
@@ -83,20 +83,19 @@ def get_query() -> str:
     return request.args.get('query', '')
 
 
-@app.route('/classes')
-@app.route('/classes/<class_>')
-@app.route('/classes/<class_>/<country>')
+@app.route('/articles')
+@app.route('/articles/<class_>')
+@app.route('/articles/<class_>/<country>')
 def classes(class_=None, country=None):
     db_handler = DBHandler(**cfg['db_handler'])
-    return jsonify(db_handler.classes(class_, country, get_start(), get_limit(), get_lang(), get_query()))
+    return jsonify(db_handler.articles(class_, country, get_start(), get_limit(), get_lang(), get_query()))
 
 
-@app.route('/countries')
-@app.route('/countries/<country>')
-@app.route('/countries/<country>/<class_>')
-def countries(country=None, class_=None):
+@app.route('/tweets')
+@app.route('/tweets/<country>')
+def tweets(country=None):
     db_handler = DBHandler(**cfg['db_handler'])
-    return jsonify(db_handler.countries(country, class_, get_start(), get_limit(), get_lang()))
+    return jsonify(db_handler.tweets(country, get_start(), get_limit(), get_lang()))
 
 
 @app.route('/update', methods=['POST'])

--- a/app.py
+++ b/app.py
@@ -91,7 +91,7 @@ def get_query() -> str:
 @app.route('/articles')
 @app.route('/articles/<class_>')
 @app.route('/articles/<class_>/<country>')
-def classes(class_=None, country=None):
+def articles(class_=None, country=None):
     return jsonify(db_handler.articles(class_, country, get_start(), get_limit(), get_lang(), get_query()))
 
 

--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ def articles(class_=None, country=None):
 @app.route('/tweets')
 @app.route('/tweets/<country>')
 def tweets(country=None):
-    return jsonify(db_handler.tweets(country, get_start(), get_limit(), get_lang()))
+    return jsonify(db_handler.tweets(country, get_start(), get_limit(), get_lang(), get_query()))
 
 
 @app.route('/update', methods=['POST'])

--- a/cron.py
+++ b/cron.py
@@ -22,11 +22,13 @@ logging.basicConfig(level='DEBUG')
 
 cfg = load_config()
 
+meta_data_handler = MetaDataHandler()
+db_handler = DBHandler(**cfg['db_handler'])
+log_handler = LogHandler(**cfg['log_handler'])
+twitter_handler = TwitterHandler(**cfg['twitter_handler'])
+
 
 def update_database(do_tweet: bool = False):
-    db_handler = DBHandler(**cfg['db_handler'])
-    log_handler = LogHandler(**cfg['log_handler'])
-
     logger.debug('Add automatically categorized pages.')
     data_path = cfg['data']['article_list']
     maybe_tweeted_ds = []
@@ -59,7 +61,6 @@ def update_database(do_tweet: bool = False):
 
     logger.debug('Tweet a useful new page.')
     if do_tweet:
-        twitter_handler = TwitterHandler(**cfg['twitter_handler'])
         if not maybe_tweeted_ds:
             logger.debug('No such pages. Skip to tweet a page.')
             return
@@ -69,9 +70,6 @@ def update_database(do_tweet: bool = False):
 
 
 def update_stats():
-    meta_data_handler = MetaDataHandler()
-    log_handler = LogHandler(**cfg['log_handler'])
-
     logger.debug('Update stats.')
     base = 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data' \
            '/csse_covid_19_time_series/ '
@@ -116,9 +114,6 @@ def update_stats():
 
 
 def update_sources():
-    meta_data_handler = MetaDataHandler()
-    log_handler = LogHandler(**cfg['log_handler'])
-
     logger.debug('Update sources.')
     data_path = cfg['data']['site_list']
     with open(data_path) as f:

--- a/db_handler.py
+++ b/db_handler.py
@@ -137,7 +137,7 @@ class DBHandler:
             document_['status'] = Status.IGNORED
         return document_
 
-    def classes(self, etopic: str, ecountry: str, start: int, limit: int, lang: str, query: str):
+    def articles(self, etopic: str, ecountry: str, start: int, limit: int, lang: str, query: str):
         if etopic == 'search':
             return self.search(ecountry, start, limit, lang, query)
 
@@ -167,32 +167,12 @@ class DBHandler:
                     reshaped_pages[etopic][ecountry] = self.get_pages(itopics, icountries, start, limit, lang)
         return reshaped_pages
 
-    def countries(self, ecountry: str, etopic: str, start: int, limit: int, lang: str):
-        etopic = ETOPIC_TRANS_MAP.get((etopic, 'ja'), etopic)
-        ecountry = ECOUNTRY_TRANS_MAP.get((ecountry, 'ja'), ecountry)
-
-        if ecountry and etopic:
-            itopics = ETOPIC_ITOPICS_MAP.get(etopic, [])
+    def tweets(self, ecountry: str, start: int, limit: int, lang: str):
+        if ecountry:
             icountries = ECOUNTRY_ICOUNTRIES_MAP.get(ecountry, [])
-            reshaped_pages = self.get_pages(itopics, icountries, start, limit, lang)
-        elif ecountry:
-            icountries = ECOUNTRY_ICOUNTRIES_MAP.get(ecountry, [])
-            reshaped_pages = {}
-            for etopic, itopics in ETOPIC_ITOPICS_MAP.items():
-                if etopic == 'all':
-                    continue
-                reshaped_pages[etopic] = self.get_pages(itopics, icountries, start, limit, lang)
+            return []
         else:
-            reshaped_pages = {}
-            for ecountry, icountries in ECOUNTRY_ICOUNTRIES_MAP.items():
-                if ecountry == 'all':
-                    continue
-                reshaped_pages[ecountry] = {}
-                for etopic, itopics in ETOPIC_ITOPICS_MAP.items():
-                    if etopic == 'all':
-                        continue
-                    reshaped_pages[ecountry][etopic] = self.get_pages(itopics, icountries, start, limit, lang)
-        return reshaped_pages
+            return {}
 
     def search(self, ecountry: str, start: int, limit: int, lang: str, query: str):
         def get_es_query(regions: List[str]):

--- a/db_handler.py
+++ b/db_handler.py
@@ -145,11 +145,15 @@ class DBHandler:
         ecountry = ECOUNTRY_TRANS_MAP.get((ecountry, 'ja'), ecountry)
 
         if etopic and ecountry:
-            itopics = ETOPIC_ITOPICS_MAP.get(etopic, [])
-            icountries = ECOUNTRY_ICOUNTRIES_MAP.get(ecountry, [])
+            if etopic not in ETOPIC_ITOPICS_MAP or ecountry not in ECOUNTRY_ICOUNTRIES_MAP:
+                return []
+            itopics = ETOPIC_ITOPICS_MAP[etopic]
+            icountries = ECOUNTRY_ICOUNTRIES_MAP[ecountry]
             reshaped_pages = self.get_pages(itopics, icountries, start, limit, lang)
         elif etopic:
-            itopics = ETOPIC_ITOPICS_MAP.get(etopic, [])
+            if etopic not in ETOPIC_ITOPICS_MAP:
+                return {ecountry: [] for ecountry in ECOUNTRY_ICOUNTRIES_MAP.keys()}
+            itopics = ETOPIC_ITOPICS_MAP[etopic]
             reshaped_pages = {}
             for ecountry, icountries in ECOUNTRY_ICOUNTRIES_MAP.items():
                 if ecountry == 'all':

--- a/db_handler.py
+++ b/db_handler.py
@@ -171,12 +171,33 @@ class DBHandler:
                     reshaped_pages[etopic][ecountry] = self.get_pages(itopics, icountries, start, limit, lang)
         return reshaped_pages
 
-    def tweets(self, ecountry: str, start: int, limit: int, lang: str):
+    def tweets(self, ecountry: str, start: int, limit: int, lang: str, query: str):
         if ecountry:
-            icountries = ECOUNTRY_ICOUNTRIES_MAP.get(ecountry, [])
-            return []
+            return [
+                {
+                    'id': '1357006259413635076',
+                    'name': "nlpforcovid-19",
+                    'verified': True,
+                    'username': "nlpforcovid",
+                    'avatar': "https://pbs.twimg.com/profile_images/1347024085952331778/3oBHXOOn_bigger.jpg",
+                    'contentOrig': "欧州がより多くのワクチンを求めている（ヨーロッパ，経済・福祉政策のニュース，France 24",
+                    'contentTrans': None,
+                    'timestamp': "2021-02-10 14:45:03"
+                },
+            ]
         else:
-            return {}
+            return {
+                ecountry: {
+                    'id': '1357006259413635076',
+                    'name': "nlpforcovid-19",
+                    'verified': True,
+                    'username': "nlpforcovid",
+                    'avatar': "https://pbs.twimg.com/profile_images/1347024085952331778/3oBHXOOn_bigger.jpg",
+                    'contentOrig': "欧州がより多くのワクチンを求めている（ヨーロッパ，経済・福祉政策のニュース，France 24",
+                    'contentTrans': None,
+                    'timestamp': "2021-02-10 14:45:03"
+                } for ecountry in ECOUNTRY_ICOUNTRIES_MAP.keys()
+            }
 
     def search(self, ecountry: str, start: int, limit: int, lang: str, query: str):
         def get_es_query(regions: List[str]):


### PR DESCRIPTION
## What

Add an API to return Twitter data. According to this update, change the conventional API design. Now the server provides the following APIs:

- /tweets/\<country\>
- /articles/\<class_\>/\<country\>
- ~~/classes/\<class_\>/\<country\>~~
- ~~/countries/\<country\>/\<class_\>~~
- ... (same as before)

To distinguish tweets from articles, `/classes` is renamed to `/articles`. As `/countries` is not used, it is deleted.
